### PR TITLE
Added shutdown functionality

### DIFF
--- a/WindowsApp1/Compact.Designer.vb
+++ b/WindowsApp1/Compact.Designer.vb
@@ -87,6 +87,7 @@ Partial Class Compact
         Me.TabPage3 = New System.Windows.Forms.TabPage()
         Me.testFileArgs = New System.Windows.Forms.Button()
         Me.ToolTipFilesCompressed = New System.Windows.Forms.ToolTip(Me.components)
+        Me.checkShutdown = New System.Windows.Forms.CheckBox()
         Me.Panel1.SuspendLayout()
         Me.TabControl1.SuspendLayout()
         Me.InputPage.SuspendLayout()
@@ -666,6 +667,7 @@ Partial Class Compact
         Me.Panel2.Anchor = CType((((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Bottom) _
             Or System.Windows.Forms.AnchorStyles.Left) _
             Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
+        Me.Panel2.Controls.Add(Me.checkShutdown)
         Me.Panel2.Controls.Add(Me.checkShowConOut)
         Me.Panel2.Controls.Add(Me.conOut)
         Me.Panel2.Location = New System.Drawing.Point(3, 285)
@@ -837,6 +839,16 @@ Partial Class Compact
         Me.ToolTipFilesCompressed.ToolTipIcon = System.Windows.Forms.ToolTipIcon.Info
         Me.ToolTipFilesCompressed.ToolTipTitle = "Information"
         '
+        'checkShutdown
+        '
+        Me.checkShutdown.AutoSize = True
+        Me.checkShutdown.Location = New System.Drawing.Point(228, 3)
+        Me.checkShutdown.Name = "checkShutdown"
+        Me.checkShutdown.Size = New System.Drawing.Size(146, 17)
+        Me.checkShutdown.TabIndex = 33
+        Me.checkShutdown.Text = "Shutdown On Completion"
+        Me.checkShutdown.UseVisualStyleBackColor = True
+        '
         'Compact
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
@@ -942,4 +954,5 @@ Partial Class Compact
     Friend WithEvents conOut As ListBox
     Friend WithEvents Panel2 As Panel
     Friend WithEvents TableLayoutPanel2 As TableLayoutPanel
+    Friend WithEvents checkShutdown As CheckBox
 End Class

--- a/WindowsApp1/Compact.vb
+++ b/WindowsApp1/Compact.vb
@@ -366,6 +366,12 @@ Public Class Compact
 
         End If
 
+        If uncompressFinished OrElse compressFinished Then                                      'Check if we're done compressing or decompressing
+            If checkShutdown.Checked Then                                                       'Check if shutdown is checked
+                checkShutdown.Checked = False                                                   'Cleaning up for Tab change. This is more for 'sleep'
+                pcControl("shutdown")
+            End If
+        End If
 
         If compressFinished = 1 Then                                                            'Hides and shows certain UI elements when compression is finished or if a compression status is being checked
 
@@ -382,6 +388,8 @@ Public Class Compact
             returnArrow.Visible = True
             CalculateSaving()
             QdirCountProgress = 0
+
+
         End If
 
         If uncompressFinished = 1 Then                                                          'Hides and shows certain UI elements when uncompression is finished 
@@ -394,7 +402,6 @@ Public Class Compact
 
 
         End If
-
 
 
     End Sub
@@ -649,6 +656,7 @@ Public Class Compact
 
     Private Sub ReturnArrow_Click(sender As Object, e As EventArgs) Handles returnArrow.Click                       'Returns you to the first screen and cleans up some stuff
 
+        checkShutdown.Checked = False
         returnArrow.Visible = False
         buttonRevert.Visible = False
         CompResultsPanel.Visible = False
@@ -821,7 +829,19 @@ Public Class Compact
     End Sub
 
 
-
+    Private Sub pcControl(state As String)                                                                                      'The added cases are for possible future use of allowing users multiple pc controls
+        Select Case state
+            Case "hybrid"       'This is for Windows 10 fastboot-based hybrid shutdown
+                Process.Start("shutdown", "/s /hybrid /t 0")
+                Me.Close()
+            Case "shutdown"
+                Process.Start("shutdown", "/s /t 0")
+                Me.Close()
+            Case "sleep"
+                Application.SetSuspendState(PowerState.Suspend, True, True)
+                'Me.Close()     'Up to dev whether app should be present after sleep
+        End Select
+    End Sub
 
     Private Sub Queryaftercompact()
         isQueryMode = 1
@@ -1170,10 +1190,7 @@ Public Class Compact
         'MsgBox(compactArgs)
     End Sub
 
-
-
-
-
-
-
+	
+	
+	
 End Class


### PR DESCRIPTION
I've added a shutdown checkbox next to the list checkbox.
Shutdown checks against either decompress or compress switches.
The actual shutdown logic also has hybrid shutdown (for Windows 10 fastboot-enabled PC's) as well as sleep. This is for possible use in the future should there be an option to allow for either of the 3. Maybe a ComboBox instead of the shutdown checkbox??